### PR TITLE
added missing bower.json file

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,14 @@
+{
+  "name": "SidebarTransitions",
+  "homepage": "https://github.com/codrops/SidebarTransitions",
+  "_release": "ab5f998ca8",
+  "_resolution": {
+    "type": "branch",
+    "branch": "master",
+    "commit": "ab5f998ca8174588f595533aacdc5533845ffd05"
+  },
+  "_source": "git://github.com/codrops/SidebarTransitions.git",
+  "_target": "*",
+  "_originalSource": "SidebarTransitions",
+  "_direct": true
+}

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,12 @@
 {
   "name": "SidebarTransitions",
   "homepage": "https://github.com/codrops/SidebarTransitions",
+  "main": [
+    "css/component.css",
+    "js/modernizr.custom.js",
+    "js/classie.js",
+    "js/sidebarEffects.js"
+  ],
   "_release": "ab5f998ca8",
   "_resolution": {
     "type": "branch",


### PR DESCRIPTION
When this repo is installed with bower, the bower.json file is present but normally it does not have this file. This fixes the discrepancy for the repo. 

This fix will allow other plugins to work with the repo e.g. wiredep